### PR TITLE
fix: keepalive & bump to 1.7.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ Maven:
 <dependency>
     <groupId>com.arenareturns</groupId>
     <artifactId>SimpleNet</artifactId>
-    <version>1.7.2</version>
+    <version>1.7.3</version>
 </dependency>
 ```
 
 Gradle:
 
 ```groovy
-implementation 'com.arenareturns:SimpleNet:1.7.2'
+implementation 'com.arenareturns:SimpleNet:1.7.3'
 ```
 
  2. Because SimpleNet is compiled with Java 11, you must first require its module in your `module-info.java`:

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.arenareturns</groupId>
     <artifactId>SimpleNet</artifactId>
-    <version>1.7.2</version>
+    <version>1.7.3</version>
 
     <name>SimpleNet</name>
     <description>ArenaReturns' fork of SimpleNet, an easy-to-use, event-driven, asynchronous network application framework compiled with Java 11.</description>

--- a/src/main/java/com/arenareturns/simplenet/Client.java
+++ b/src/main/java/com/arenareturns/simplenet/Client.java
@@ -39,6 +39,7 @@ import com.arenareturns.simplenet.utility.exposed.data.FloatReader;
 import com.arenareturns.simplenet.utility.exposed.data.IntReader;
 import com.arenareturns.simplenet.utility.exposed.data.LongReader;
 import com.arenareturns.simplenet.utility.exposed.data.StringReader;
+import jdk.net.ExtendedSocketOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -419,7 +420,10 @@ public class Client extends AbstractReceiver<Runnable> implements Channeled<Asyn
             this.channel = AsynchronousSocketChannel.open(group = AsynchronousChannelGroup.withThreadPool(executor));
             this.channel.setOption(StandardSocketOptions.SO_RCVBUF, BUFFER_SIZE);
             this.channel.setOption(StandardSocketOptions.SO_SNDBUF, BUFFER_SIZE);
-            this.channel.setOption(StandardSocketOptions.SO_KEEPALIVE, false);
+            this.channel.setOption(StandardSocketOptions.SO_KEEPALIVE, true);
+            this.channel.setOption(ExtendedSocketOptions.TCP_KEEPCOUNT, 3);
+            this.channel.setOption(ExtendedSocketOptions.TCP_KEEPIDLE, 30);
+            this.channel.setOption(ExtendedSocketOptions.TCP_KEEPINTERVAL, 5);
             this.channel.setOption(StandardSocketOptions.TCP_NODELAY, true);
         } catch (IOException e) {
             throw new IllegalStateException("Unable to open the channel!", e);

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,6 +1,7 @@
 module com.arenareturns.simplenet {
     requires org.slf4j;
     requires com.arenareturns.pbbl;
+    requires jdk.net;
 
     exports com.arenareturns.simplenet;
     exports com.arenareturns.simplenet.packet;


### PR DESCRIPTION
- Enable keepalive
- Send a TCP keepalive every 30 seconds if there's no packet received
- If the keepalive has no response, retry every 5 seconds for a maximum of 3 times
- Close the connection if still no response after that